### PR TITLE
ci: make build-environment workflow callable

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -6,6 +6,18 @@ on:
     branches:
       - "main"
 
+  workflow_call:
+    inputs:
+      tag:
+        description: "A tag to use for the container image."
+        required: false
+        type: string
+      ref:
+        description: "The git ref to checkout and build."
+        required: false
+        default: "main"
+        type: string
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -26,10 +40,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set Container Image Tag
+        id: tag
+        run: |
+          if [ -z "${{ inputs.tag }}" ]; then
+            echo ::set-output name=tag::"latest"
+          else
+            echo ::set-output name=tag::"${{ inputs.tag }}"
+          fi
+
       - name: Build Buildenv Container
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: mrohrich/buildenv-radosgw:latest
+          tags: mrohrich/buildenv-radosgw:${{ steps.tag.outputs.tag }}
           file: 'build/Dockerfile.build-radosgw'
           context: 'build'


### PR DESCRIPTION
Make the build-environment callable. This will be used to create tagged
container images when the aquarist-labs/s3gw repo is tagged and a
project release is triggered.

The aim is that the container tagged with :latest contains the latest
changes in this repo. But there are also containers tagged with the
project's release version containing the correct contents for that
specific release.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>