### PR TITLE
Adapt the access/secret key in s3cmd.cfg to the values that are deployed by the scripts.

### DIFF
--- a/env/s3cmd.cfg
+++ b/env/s3cmd.cfg
@@ -1,5 +1,5 @@
 [default]
-access_key = test
+access_key = 0555b35654ad1656d804
 access_token =
 add_encoding_exts =
 add_headers =
@@ -62,10 +62,10 @@ reduced_redundancy = False
 requester_pays = False
 restore_days = 1
 restore_priority = Standard
-secret_key = test
+secret_key = h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==
 send_chunk = 65536
 server_side_encryption = False
-signature_v2 = False
+signature_v2 = True
 signurl_use_https = False
 simpledb_host = sdb.amazonaws.com
 skip_existing = False


### PR DESCRIPTION
See [env/s3gw/s3gw-secret.yaml](https://github.com/aquarist-labs/s3gw-tools/blob/main/env/s3gw/s3gw-secret.yaml) file.

Signed-off-by: Volker Theile <vtheile@suse.com>