### PR TITLE
ci: use credentials provided by caller

### DIFF
--- a/.github/workflows/build-environment.yaml
+++ b/.github/workflows/build-environment.yaml
@@ -17,6 +17,16 @@ on:
         required: false
         default: "main"
         type: string
+      dockerhub_username:
+        description: "A username to use for push to dockerhub"
+        required: true
+        default: ${{ secrets.DOCKERHUB_USERNAME }}
+        type: string
+      dockerhub_token:
+        description: "A token to use for push to dockerhub"
+        required: true
+        default: ${{ secrets.DOCKERHUB_TOKEN }}
+        type: string
 
 jobs:
   build:
@@ -37,8 +47,8 @@ jobs:
       - name: Dockerhub Login
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ inputs.dockerhub_username }}
+          password: ${{ inputs.dockerhub_token }}
 
       - name: Set Container Image Tag
         id: tag
@@ -53,6 +63,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          tags: mrohrich/buildenv-radosgw:${{ steps.tag.outputs.tag }}
+          tags: ${{ inputs.dockerhub_username }}/buildenv-radosgw:${{ steps.tag.outputs.tag }}
           file: 'build/Dockerfile.build-radosgw'
           context: 'build'


### PR DESCRIPTION
Use credentials provided by caller when the workflow is called from a different repo. This is needed for when the workflow is called from the s3gw repo since secrets are not accessible in called workflows.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>