### PR TITLE
test/smoke: Delete bucket in smoke test

### DIFF
--- a/tests/s3gw-smoke-test.sh
+++ b/tests/s3gw-smoke-test.sh
@@ -128,5 +128,17 @@ newbucket="${bucket}-2"
 s3 mb s3://${newbucket} || exit 1
 do_copy ${newbucket}
 
+# delete the bucket contents
+s3 del --recursive --force s3://${bucket}
+
+# list the bucket, it should be empty
+lst=($(s3 ls s3://${bucket}))
+[[ ${#lst[@]} -eq 0 ]] || exit 1
+
+# remove the bucket
+s3 rb s3://${bucket}
+
+# should no longer be available
+s3 ls s3://${bucket} && exit 1
 
 exit 0


### PR DESCRIPTION
After PR https://github.com/aquarist-labs/ceph/pull/43 is merged we are able now to delete the bucket in the smoke test.

Signed-off-by: Xavi Garcia <xavi.garcia@suse.com>

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] CHANGELOG.md has been updated should there be relevant changes in this PR.
