### PR TITLE
build/s3gw-test: s3gw-test image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [Unreleased]
 
 - added '--longhorn-custom-settings' option to env/setup.sh to install longhorn
   using custom settings.
+- added the ability to build a s3gw-test image able to run google-tests related to
+  radosgw sfs backend development.
 
 ## [0.4.0] - 2022-09-01
 

--- a/build/Dockerfile.build-radosgw-test-container
+++ b/build/Dockerfile.build-radosgw-test-container
@@ -1,0 +1,51 @@
+FROM opensuse/tumbleweed
+LABEL Name=s3gw-test
+
+RUN zypper -n install \
+  libblkid1 \
+  libexpat1 \
+  libtcmalloc4 \
+  libfmt8 \
+  liboath0 \
+  libicu71 \
+  libthrift-0_16_0 \
+  libboost_atomic1_80_0 \
+  libboost_chrono1_80_0 \
+  libboost_context1_80_0 \
+  libboost_coroutine1_80_0 \
+  libboost_date_time1_80_0 \
+  libboost_filesystem1_80_0 \
+  libboost_iostreams1_80_0 \
+  libboost_program_options1_80_0 \
+  libboost_random1_80_0 \
+  libboost_regex1_80_0 \
+  libboost_serialization1_80_0 \
+  libboost_system1_80_0 \
+  libboost_thread1_80_0 \
+ && zypper clean --all
+
+COPY ./bin/unittest_rgw_sfs_sqlite_users /usr/bin/unittest_rgw_sfs_sqlite_users
+COPY ./bin/unittest_rgw_sfs_sqlite_buckets /usr/bin/unittest_rgw_sfs_sqlite_buckets
+COPY ./bin/unittest_rgw_sfs_sqlite_objects /usr/bin/unittest_rgw_sfs_sqlite_objects
+COPY ./bin/unittest_rgw_sfs_sqlite_versioned_objects /usr/bin/unittest_rgw_sfs_sqlite_versioned_objects
+COPY ./bin/unittest_rgw_sfs_sfs_bucket /usr/bin/unittest_rgw_sfs_sfs_bucket
+COPY [ "./lib/libradosgw.so", \
+       "./lib/libradosgw.so.2", \
+       "./lib/libradosgw.so.2.0.0", \
+       "./lib/librados.so", \
+       "./lib/librados.so.2", \
+       "./lib/librados.so.2.0.0", \
+       "./lib/libceph-common.so", \
+       "./lib/libceph-common.so.2", \
+       "/usr/lib64/" ]
+
+RUN touch /usr/bin/run_tests.sh && chmod +x /usr/bin/run_tests.sh
+RUN echo -e "#!/bin/bash\n\
+unittest_rgw_sfs_sqlite_users || exit 1\n\
+unittest_rgw_sfs_sqlite_buckets || exit 1\n\
+unittest_rgw_sfs_sqlite_objects || exit 1\n\
+unittest_rgw_sfs_sqlite_versioned_objects || exit 1\n\
+unittest_rgw_sfs_sfs_bucket || exit 1\n" \
+> /usr/bin/run_tests.sh
+
+ENTRYPOINT ["/usr/bin/run_tests.sh"]

--- a/build/build-radosgw-test-container.sh
+++ b/build/build-radosgw-test-container.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e
+
+IMAGE_NAME=${IMAGE_NAME:-"s3gw-test"}
+CEPH_DIR=$(realpath ${CEPH_DIR:-"../../ceph/"})
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-"podman"}
+
+registry=
+registry_args=
+
+build_test_container_image() {
+  echo "Building test container image ..."
+
+  case ${CONTAINER_ENGINE} in
+  podman)
+    podman build -t ${IMAGE_NAME} -f ./Dockerfile.build-radosgw-test-container ${CEPH_DIR}/build
+    ;;
+  docker)
+    docker build -t localhost/${IMAGE_NAME} -f ./Dockerfile.build-radosgw-test-container ${CEPH_DIR}/build
+    ;;
+  esac
+}
+
+push_test_container_image() {
+  if [ -n "${registry}" ]; then
+    echo "Pushing test container image to registry ..."
+    ${CONTAINER_ENGINE} push ${registry_args} localhost/${IMAGE_NAME} \
+      ${registry}/${IMAGE_NAME}
+  fi
+}
+
+while [ $# -ge 1 ]; do
+  case $1 in
+    --registry)
+      registry=$2
+      shift
+      ;;
+    --no-registry-tls)
+      registry_args="--tls-verify=false"
+      ;;
+  esac
+  shift
+done
+
+build_test_container_image
+push_test_container_image
+
+exit 0

--- a/build/build-radosgw.sh
+++ b/build/build-radosgw.sh
@@ -11,18 +11,20 @@ CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-"Debug"}
 
 CEPH_DIR=$(realpath ${CEPH_DIR:-"/srv/ceph"})
 S3GW_CCACHE_DIR=${S3GW_CCACHE_DIR:-"${CEPH_DIR}/build.ccache"}
+WITH_TESTS=${WITH_TESTS:-"OFF"}
+WITH_RADOSGW_DBSTORE=${WITH_RADOSGW_DBSTORE:-"OFF"}
 
 CEPH_CMAKE_ARGS=(
   "-DENABLE_GIT_VERSION=ON"
   "-DWITH_PYTHON3=3"
   "-DWITH_CCACHE=ON"
-  "-DWITH_TESTS=OFF"
+  "-DWITH_TESTS=${WITH_TESTS}"
   "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
   "-DWITH_RADOSGW_AMQP_ENDPOINT=OFF"
   "-DWITH_RADOSGW_KAFKA_ENDPOINT=OFF"
   "-DWITH_RADOSGW_SELECT_PARQUET=OFF"
   "-DWITH_RADOSGW_MOTR=OFF"
-  "-DWITH_RADOSGW_DBSTORE=ON"
+  "-DWITH_RADOSGW_DBSTORE=${WITH_RADOSGW_DBSTORE}"
   "-DWITH_RADOSGW_LUA_PACKAGES=OFF"
   "-DWITH_MANPAGE=OFF"
   "-DWITH_OPENLDAP=OFF"
@@ -39,6 +41,8 @@ build_radosgw() {
   echo "NPROC=${NPROC}"
   echo "CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
   echo "CCACHE_DIR=${S3GW_CCACHE_DIR}"
+  echo "WITH_TESTS=${WITH_TESTS}"
+  echo "WITH_RADOSGW_DBSTORE=${WITH_RADOSGW_DBSTORE}"
 
   export CCACHE_DIR=${S3GW_CCACHE_DIR}
   if [ ! -d "${CCACHE_DIR}" ]; then
@@ -75,7 +79,43 @@ strip_radosgw() {
     ${CEPH_DIR}/build/lib/*.so
 }
 
+build_radosgw_test() {
+  echo "Building radosgw test..."
+
+  export CCACHE_DIR=${S3GW_CCACHE_DIR}
+  if [ ! -d "${CCACHE_DIR}" ]; then
+    echo "ccache dir not found, create."
+    mkdir "${CCACHE_DIR}"
+    echo "Created by aquarist-labs/s3gw-tools build-radosgw container" > \
+      "${CCACHE_DIR}/README"
+  fi
+
+  cd ${CEPH_DIR}
+
+  # This is necessary since git v2.35.2 because of CVE-2022-24765
+  # but we have to continue in case CEPH_DIR is not a git repo
+  git config --global --add safe.directory "${CEPH_DIR}" || true
+
+  if [ -d "build" ]; then
+      cd build/
+      cmake -DBOOST_J=${NPROC} ${CEPH_CMAKE_ARGS[@]} ..
+  else
+      ./do_cmake.sh ${CEPH_CMAKE_ARGS[@]}
+      cd build/
+  fi
+
+  ninja -j${NPROC} bin/unittest_rgw_sfs_sqlite_users
+  ninja -j${NPROC} bin/unittest_rgw_sfs_sqlite_buckets
+  ninja -j${NPROC} bin/unittest_rgw_sfs_sqlite_objects
+  ninja -j${NPROC} bin/unittest_rgw_sfs_sqlite_versioned_objects
+  ninja -j${NPROC} bin/unittest_rgw_sfs_sfs_bucket
+}
+
 build_radosgw
 strip_radosgw
+
+if [ "${WITH_TESTS}" == "ON" ]; then
+  build_radosgw_test
+fi
 
 exit 0


### PR DESCRIPTION
# Describe your changes

Note: this PR alone is not sufficient to cover the [issue](https://github.com/aquarist-labs/s3gw/issues/94)'s functional requisite.
Other PR(s) will be opened on the relevant repos.

Added the ability to build a s3gw-test image able to run google-tests related to radosgw sfs backend development.

example steps:

```
./build.sh build-image
S3GW_CEPH_DIR=../../ceph S3GW_CCACHE_DIR=../../ceph/build.ccache.s3gw WITH_TESTS=ON ./build.sh radosgw
S3GW_CEPH_DIR=../../ceph ./build.sh s3gw-test
podman run localhost/s3gw-test
```

## Issue ticket number and link

https://github.com/aquarist-labs/s3gw/issues/94

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
