### PR TITLE
build: fix git safe dir

### DIFF
--- a/build/build-radosgw.sh
+++ b/build/build-radosgw.sh
@@ -58,7 +58,8 @@ build_radosgw() {
 
   # This is necessary since git v2.35.2 because of CVE-2022-24765
   # but we have to continue in case CEPH_DIR is not a git repo
-  git config --global --add safe.directory "${CEPH_DIR}" || true
+  # Since git 2.36 the the wildcard '*' is also accepted
+  git config --global --add safe.directory "*" || true
 
   if [ -d "build" ]; then
       cd build/
@@ -96,7 +97,7 @@ build_radosgw_test() {
 
   # This is necessary since git v2.35.2 because of CVE-2022-24765
   # but we have to continue in case CEPH_DIR is not a git repo
-  git config --global --add safe.directory "${CEPH_DIR}" || true
+  git config --global --add safe.directory "*" || true
 
   if [ -d "build" ]; then
       cd build/


### PR DESCRIPTION
Assuming at least git 2.36 is used, this fixes the git safe.directory debacle when building as different user (e.g. root in a container ) than the one owning the git repo's directory.

Signed-off-by: Moritz Röhrich <moritz.rohrich@suse.com>

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] CHANGELOG.md has been updated should there be relevant changes in this PR.
